### PR TITLE
feat: allow to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ ADD go.mod /code/
 RUN go mod download
 ADD . /code/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /code/scws .
+RUN chmod a+x /code/scws
 
 
 FROM alpine:3.6
 WORKDIR /root/
 RUN apk --no-cache --update add bash curl less jq openssl
-COPY --from=builder /code/scws /root/
-CMD /root/scws
+COPY --from=builder /code/scws /usr/local/bin/scws
+CMD /usr/local/bin/scws


### PR DESCRIPTION
This update allows to run as non-root:

```bash
$ docker run -u 1000:100 --rm -it local/scws
2021/10/15 08:34:51 Storage type: filesystem
2021/10/15 08:34:51 Listening :8080
```

Without:

```bash
$ docker run -u 1000:100 --rm -it local/scws
/bin/sh: /root/scws: Permission denied
```